### PR TITLE
dont save nodeport

### DIFF
--- a/src/k8sResourceManager.js
+++ b/src/k8sResourceManager.js
@@ -63,6 +63,10 @@ class K8sResourceManager {
   async redirectService(serviceName, namespace) {
     try {
       const service = (await k8sApi.readNamespacedService(serviceName, namespace)).body;
+      // Do not save NodePort values, as they are automatically set by k8s and we do not depend on them
+      service.spec.ports.forEach((port) => {
+        delete port["nodePort"]
+      });
 
       if (!service.metadata.annotations || service.metadata.annotations['auto-downscale/down'] != 'true') {
 


### PR DESCRIPTION
Various services are set to NodePort type, even though we do not use their specific functionality.

k8s automatically assigns a random nodeport for these services.
When upscaler tries to restore a service, there is a chance that the saved nodeport is already claimed by some other serivce, thus failing the operation.

This PR removes NodePort value from being saved for services.

![Screenshot from 2023-05-11 13-36-14](https://github.com/wunderio/silta-downscaler/assets/22932648/0332a269-2941-4cde-bf0c-ff3f749c25d0)
Pictured: original service definition (first 2 entries), followed by what will be saved for restoration.
 